### PR TITLE
arregado bug en clase guardar(), cambio de operadores lógicos de && a ||

### DIFF
--- a/AD_ACT_01_Fichero/src/modelo/negocio/GestorVideojuego.java
+++ b/AD_ACT_01_Fichero/src/modelo/negocio/GestorVideojuego.java
@@ -55,15 +55,15 @@ public class GestorVideojuego {
 
         dvf = new DaoVideojuegoFichero();
         try {
-            if (v.getNombre() == null && v.getNombre().isBlank() && v.getNombre().length() < 3) {
+            if (v.getNombre() == null || v.getNombre().isBlank()|| v.getNombre().length() < 3) {
                 return 1; 
             }
 
-            if (v.getCompania() == null && v.getCompania().isBlank() && v.getCompania().length() < 5) {
+            if (v.getCompania() == null || v.getCompania().isBlank() || v.getCompania().length() < 5) {
                 return 2; 
             }
 
-            if (v.getNota() < 0 && v.getNota() > 100) {
+            if (v.getNota() < 0 || v.getNota() > 100) {
                 return 3; 
             }
 
@@ -88,7 +88,5 @@ public class GestorVideojuego {
         }
     }
 
-    
-    
-    
+   
 }


### PR DESCRIPTION
Este pull request soluciona un bug encontrado en la clase guardar() gracias a las pruebas unitarias realizadas con JUnit. Anteriormente, se utilizaban operadores lógicos && para validar ciertos campos, lo que causaba un comportamiento incorrecto en las validaciones, entonces lo he sustituido por ||